### PR TITLE
FIX: patch store to unfreeze encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 libspikedevices.so
+*.log
+*.bin

--- a/src/trace_encoder_ctrl.cc
+++ b/src/trace_encoder_ctrl.cc
@@ -21,6 +21,10 @@ bool trace_encoder_ctrl_t::store(reg_t addr, size_t len, const uint8_t* bytes) {
             printf("[TRACE_ENCODER_CTRL]: Setting enable to %d\n", (bytes[0] >> 1) & 0x1);
             this->encoder->set_enable((bytes[0] >> 1) & 0x1); // Set enable to the second bit
             return true;
+        case TR_TE_TARGET:
+            // printf("[TRACE_ENCODER_CTRL]: Setting enable to %d\n", (bytes[0] >> 1) & 0x1);
+            // this->encoder->set_enable((bytes[0] >> 1) & 0x1);
+            return true;
         default:
             return false;
     }

--- a/src/trace_encoder_ctrl.h
+++ b/src/trace_encoder_ctrl.h
@@ -12,6 +12,7 @@
 
 #define TR_TE_CTRL 0x000
 #define TR_TE_IMPL 0x004
+#define TR_TE_TARGET 0x020
 
 class trace_encoder_ctrl_t : public abstract_device_t {
 public:


### PR DESCRIPTION
Patch `trace_encoder_ctrl.cc` to not freeze when `.store` is called. Simply returns true when incoming store address is the target address `0x020`.